### PR TITLE
feat(vite): Make NX context accessible in Vite

### DIFF
--- a/packages/vite/index.ts
+++ b/packages/vite/index.ts
@@ -1,5 +1,6 @@
 export * from './src/utils/versions';
 export * from './src/utils/generator-utils';
+export { getExecutionContext } from './src/utils/executor-utils';
 export { type ViteConfigurationGeneratorSchema } from './src/generators/configuration/schema';
 export { viteConfigurationGenerator } from './src/generators/configuration/configuration';
 export { type VitestGeneratorSchema } from './src/generators/vitest/schema';

--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -25,6 +25,7 @@ import {
   createBuildableTsConfig,
   loadViteDynamicImport,
   validateTypes,
+  withExecutionContext,
 } from '../../utils/executor-utils';
 
 export async function* viteBuildExecutor(
@@ -51,12 +52,14 @@ export async function* viteBuildExecutor(
 
   const { buildOptions, otherOptions } = await getBuildExtraArgs(options);
 
-  const resolved = await loadConfigFromFile(
-    {
-      mode: otherOptions?.mode ?? 'production',
-      command: 'build',
-    },
-    viteConfigPath
+  const resolved = await withExecutionContext(context, () =>
+    loadConfigFromFile(
+      {
+        mode: otherOptions?.mode ?? 'production',
+        command: 'build',
+      },
+      viteConfigPath
+    )
   );
 
   const outDir =
@@ -87,7 +90,9 @@ export async function* viteBuildExecutor(
     });
   }
 
-  const watcherOrOutput = await build(buildConfig);
+  const watcherOrOutput = await withExecutionContext(context, () =>
+    build(buildConfig)
+  );
 
   const libraryPackageJson = resolve(projectRoot, 'package.json');
   const rootPackageJson = resolve(context.root, 'package.json');

--- a/packages/vite/src/utils/executor-utils.ts
+++ b/packages/vite/src/utils/executor-utils.ts
@@ -1,5 +1,6 @@
 import { printDiagnostics, runTypeCheck } from '@nx/js';
 import { join } from 'path';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { ViteBuildExecutorOptions } from '../executors/build/schema';
 import { ExecutorContext } from '@nx/devkit';
 import { ViteDevServerExecutorOptions } from '../executors/dev-server/schema';
@@ -8,6 +9,8 @@ import {
   createTmpTsConfig,
 } from '@nx/js/src/utils/buildable-libs-utils';
 import { getProjectTsConfigPath } from './options-utils';
+
+export const executionContextStorage = new AsyncLocalStorage<ExecutorContext>();
 
 export async function validateTypes(opts: {
   workspaceRoot: string;
@@ -61,3 +64,10 @@ export function createBuildableTsConfig(
 export function loadViteDynamicImport() {
   return Function('return import("vite")')() as Promise<typeof import('vite')>;
 }
+
+export const withExecutionContext = <T>(
+  context: ExecutorContext,
+  callback: () => T
+): T => executionContextStorage.run(context, callback);
+
+export const getExecutionContext = () => executionContextStorage.getStore();


### PR DESCRIPTION
Provide NX execution context to Vite config files.

This can be used to automagically define external modules, reuse NX paths, have CI specific configs, etc.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
